### PR TITLE
Updating Remove-App Function

### DIFF
--- a/CleanBloat.ps1
+++ b/CleanBloat.ps1
@@ -64,21 +64,23 @@ Function Remove-App-MSI-I-QN([String]$appName)
     }
 }
 
-
 Function Remove-App([String]$appName){
-    $app = Get-AppxPackage -AllUsers $appName
-    if($app -ne $null){
-        $packageFullName = $app.PackageFullName
+    $app = Get-AppxPackage -AllUsers | Where-Object { $_.Name -eq $appName }
+    if ($app -ne $null) {
         Write-Host "Uninstalling $appName"
-        Remove-AppxPackage -package $packageFullName -AllUsers
-        $provApp = Get-AppxProvisionedPackage -Online 
-        $proPackageFullName = (Get-AppxProvisionedPackage -Online | where {$_.Displayname -eq $appName}).DisplayName
-        if($proPackageFillName -ne $null){
+        foreach ($package in $app) {
+            Remove-AppxPackage -package $package.PackageFullName -AllUsers
+        }
+
+        $provApp = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $appName }
+        if ($provApp -ne $null) {
             Write-Host "Uninstalling provisioned $appName"
-            Remove-AppxProvisionedPackage -online -packagename $proPackageFullName -AllUsers
+            foreach ($package in $provApp) {
+                Remove-AppxProvisionedPackage -online -packagename $package.PackageName
+            }
         }
     }
-    else{
+    else {
         Write-Host "$appName is not installed on this computer"
     }
 }


### PR DESCRIPTION
Was having an error because it was listed multiple times. So....

The script seems to be encountering an issue with the Remove-AppxPackage command. Specifically, the error indicates that the $packageFullName variable might be an array instead of a single string, leading to the type conversion error.

To fix this, you'll want to check if there are multiple entries in $packageFullName and handle them appropriately. Here’s a revised version of the Remove-App function with an added check to loop through each entry if needed:

powershell
Copy code
Function Remove-App([String]$appName){
    $app = Get-AppxPackage -AllUsers | Where-Object { $_.Name -eq $appName }
    if ($app -ne $null) {
        Write-Host "Uninstalling $appName"
        foreach ($package in $app) {
            Remove-AppxPackage -package $package.PackageFullName -AllUsers
        }

        $provApp = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $appName }
        if ($provApp -ne $null) {
            Write-Host "Uninstalling provisioned $appName"
            foreach ($package in $provApp) {
                Remove-AppxProvisionedPackage -online -packagename $package.PackageName
            }
        }
    }
    else {
        Write-Host "$appName is not installed on this computer"
    }
}
Changes Made:
Loop through each app: If multiple instances of the app exist, it will now loop through and uninstall each instance separately. Provisioned app check: It ensures that provisioned packages are also removed if they exist. This revised function should resolve the error message related to converting a string array to a single string.